### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/bovadaAPI/decorators.py
+++ b/bovadaAPI/decorators.py
@@ -5,7 +5,7 @@ from error import BovadaException
 
 def authentication_required(func):
 	def authentication_wrapper(self, *args, **kwargs):
-		if self._auth == None:
+		if self._auth is None:
 			raise BovadaException("You must be authenticated with bovada to use this function")
 		else:
 			return func(self, *args, **kwargs)
@@ -17,7 +17,7 @@ def authentication_required(func):
 
 def authentication_recommended(func):
 	def authentication_reccommended_wrapper(self, *args, **kwargs):
-		if self._auth == None:
+		if self._auth is None:
 			print "Not authenticating first will mean the odds will be in American Format"
 			return func(self, *args, **kwargs)
 		return func(self, *args, **kwargs)

--- a/bovadaAPI/tests.py
+++ b/bovadaAPI/tests.py
@@ -44,7 +44,7 @@ class MyTest(unittest.TestCase):
 		for match in all_matches:
 			printed_link = False
 			for key, value in match.__dict__.iteritems():
-				if value == None:
+				if value is None:
 					exclude_endpoints.append(match.game_link)
 					print key + "is none"
 		print exclude_endpoints


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jkol36:bovadaAPI?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:jkol36:bovadaAPI?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
