### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bovadaAPI/Parser.py
+++ b/bovadaAPI/Parser.py
@@ -22,7 +22,7 @@ class BovadaMatch(object):
 
 	@property
 	def match_details(self):
-		return "%s, %s, %s, %s, %s, %s, %s, %s" %(self.sport, self.game_link, 
+		return "{0!s}, {1!s}, {2!s}, {3!s}, {4!s}, {5!s}, {6!s}, {7!s}".format(self.sport, self.game_link, 
 			self.description, self.startTime, self.home_team_full_name,
 			self.game_link, self.type, self.game_id)
 

--- a/bovadaAPI/bind_api.py
+++ b/bovadaAPI/bind_api.py
@@ -157,16 +157,16 @@ def get_endpoint(action, profile_id):
 		endpoint = "https://sports.bovada.lv/soccer?json=true"
 
 	elif action == "summary":
-		 endpoint = "https://www.bovada.lv/services/web/v2/profiles/%s/summary" % profile_id
+		 endpoint = "https://www.bovada.lv/services/web/v2/profiles/{0!s}/summary".format(profile_id)
 	elif action == "balance":
-		endpoint = "https://www.bovada.lv/services/web/v2/profiles/%s/summary" % profile_id
+		endpoint = "https://www.bovada.lv/services/web/v2/profiles/{0!s}/summary".format(profile_id)
 
 
 	elif action == "deposit":
 		endpoint = "https://www.bovada.lv/?pushdown=cashier.deposit"
 
 	elif action == "wallets":
-		endpoint = "https://www.bovada.lv/services/web/v2/profiles/%s/wallets" % profile_id
+		endpoint = "https://www.bovada.lv/services/web/v2/profiles/{0!s}/wallets".format(profile_id)
 
 	elif action == "basketball_matches":
 		endpoint = "https://sports.bovada.lv/basketball?json=true"
@@ -185,10 +185,10 @@ def get_endpoint(action, profile_id):
 	
 
 	elif action == "open_bets":
-		endpoint = "https://sports.bovada.lv/services/web/v2/profiles/%s/wagers?status=OPEN&channel=ALL" %profile_id
+		endpoint = "https://sports.bovada.lv/services/web/v2/profiles/{0!s}/wagers?status=OPEN&channel=ALL".format(profile_id)
 
 	elif action == "bet_history":
-		endpoint = "https://sports.bovada.lv/services/web/v2/profiles/%s/wagers?status=SETTLED&channel=ALL&days=14" %profile_id
+		endpoint = "https://sports.bovada.lv/services/web/v2/profiles/{0!s}/wagers?status=SETTLED&channel=ALL&days=14".format(profile_id)
 
 	else:
 		raise BovadaException("did not receive a valid action. Received: {}".format(action))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jkol36:bovadaAPI?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jkol36:bovadaAPI?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
